### PR TITLE
Reset anchor point at the end of the gesture. IOS

### DIFF
--- a/ios/RNPinchableView.m
+++ b/ios/RNPinchableView.m
@@ -16,6 +16,7 @@ UIView *initialSuperView;
 NSUInteger initialIndex;
 CGRect initialFrame;
 CGPoint initialTouchPoint;
+CGPoint initialAnchorPoint;
 CGPoint lastTouchPoint;
 UIView *backgroundView;
 
@@ -38,6 +39,7 @@ UIView *backgroundView;
   initialIndex = -1;
   initialFrame = CGRectZero;
   initialTouchPoint = CGPointZero;
+  initialAnchorPoint = CGPointZero;
   lastTouchPoint = CGPointZero;
   backgroundView = nil;
 }
@@ -74,6 +76,7 @@ UIView *backgroundView;
     isActive = YES;
     initialSuperView = view.superview;
     initialIndex = [initialSuperView.subviews indexOfObject:view];
+    initialAnchorPoint = view.layer.anchorPoint;
     
     CGPoint center = [gestureRecognizer locationInView:view];
     CGPoint absoluteOrigin = [view.superview convertPoint:view.frame.origin toView:window];
@@ -124,6 +127,7 @@ UIView *backgroundView;
     } completion:^(BOOL finished) {
       [backgroundView removeFromSuperview];
       [initialSuperView insertSubview:view atIndex:initialIndex];
+      view.layer.anchorPoint = initialAnchorPoint;
       view.frame = initialFrame;
       [self resetGestureState];
     }];


### PR DESCRIPTION
After pinching an Animated.Image, or Image in animated container, if I change Image's height - it jumps to a random point.
It happens because of the anchorPoint property is being changed.

Screenshots:
- right after pinch
<img width="322" alt="Screenshot 2021-09-22 at 18 37 06" src="https://user-images.githubusercontent.com/33136736/134378518-3686cd8f-5a8f-4e05-aa4e-a3ee40f6c6de.png">

- height has been changed
<img width="322" alt="Screenshot 2021-09-22 at 18 37 25" src="https://user-images.githubusercontent.com/33136736/134378508-976e9662-f300-40b1-9164-2c4145020029.png">

