### PR TITLE
[Android]: Replace deprecated drawing cache with Canvas

### DIFF
--- a/android/src/main/java/com/oblador/pinchable/PinchableView.java
+++ b/android/src/main/java/com/oblador/pinchable/PinchableView.java
@@ -5,6 +5,7 @@ import java.lang.Math;
 import android.content.Context;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.BitmapDrawable;
+import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.PointF;
 import android.graphics.Bitmap;
@@ -110,11 +111,12 @@ public class PinchableView extends ReactViewGroup implements OnTouchListener {
             rootView.getOverlay().remove(clone);
             clone = null;
         }
+        
         Bitmap snapshot = null;
-        v.setDrawingCacheEnabled(true);
-        v.setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_AUTO);
         try {
-            snapshot = Bitmap.createBitmap(v.getDrawingCache(true));
+            snapshot = Bitmap.createBitmap(v.getWidth(), v.getHeight(), Bitmap.Config.ARGB_8888);
+            Canvas canvas = new Canvas(snapshot);
+            v.draw(canvas);
             clone = new BitmapDrawable(this.getContext().getResources(), snapshot);
         } catch(Exception ex) {
             ex.printStackTrace();


### PR DESCRIPTION
**What's in here:**
This commit modifies the `startGesture` method in the PinchableView class to use a `Canvas` for creating a bitmap snapshot of the view. The previous implementation used the now-deprecated drawing cache, which could lead to compatibility and performance issues, especially in newer Android versions.

**My motivation:**
Whenever I pinch an image and then change the image dynamically, it would return the old image on the next pinch geasture. Now, that could be solved by simply writing `v.invalidate()` in the `startGesture` method to kind of make it redraw the view, but doing it in `Canvas` already solved my issue.

![s](https://github.com/oblador/react-native-pinchable/assets/76215329/7a27b72d-63ec-40f5-88b5-56bcd99453bb)
