### PR TITLE
[iOS] Prevent additional gestures while pinching

### DIFF
--- a/ios/RNPinchableView.m
+++ b/ios/RNPinchableView.m
@@ -90,7 +90,11 @@ UIView *backgroundView;
     
     view.layer.anchorPoint = anchorPoint;
     view.center = center;
-    view.frame = CGRectMake(absoluteOrigin.x, absoluteOrigin.y, initialFrame.size.width, initialFrame.size.height);
+
+    if (!isnan(absoluteOrigin.x) && !isnan(absoluteOrigin.y)) {
+      view.frame = CGRectMake(absoluteOrigin.x, absoluteOrigin.y, initialFrame.size.width, initialFrame.size.height);
+    }
+
     [initialSuperView setNeedsLayout];
     [view setNeedsLayout];
   }
@@ -114,8 +118,13 @@ UIView *backgroundView;
     transform = CGAffineTransformTranslate(transform, translate.x, translate.y);
     transform = CGAffineTransformScale(transform, scale, scale);
     view.transform = transform;
-    
-    backgroundView.layer.opacity = MIN(scale - 1., .7);
+
+    CGFloat layerOpacity = MIN(scale - 1., .7);
+    if (layerOpacity <= 0) {
+      layerOpacity = .05;
+    }
+
+    backgroundView.layer.opacity = layerOpacity;
     lastTouchPoint = currentTouchPoint;
   }
 


### PR DESCRIPTION
**The Problem**
Doing other gestures while pinching an image leads to layout issues and crashes. In my case, the user could scroll the table view behind the pinched image while the scale was at 0, which led to a crash.

**Solution**
Preventing the background view's opacity from going to zero prevents the user from doing other gestures while pinching an image.

This fix the issue #9 